### PR TITLE
adds an action to touch the cache, renewing the invalidation time

### DIFF
--- a/.github/workflows/renew_cache.yaml
+++ b/.github/workflows/renew_cache.yaml
@@ -1,0 +1,19 @@
+name: renew-cache
+on:
+  schedule:
+    - cron: "0 10 * * *"
+
+jobs:
+  renew-cache:
+    name: renew-cache
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v4
+        with:
+          key: freeze
+          path: _freeze


### PR DESCRIPTION
github action caches are removed after 7 days. This action will renew the freeze cache by using it daily, preventing the cache from every being invalidated. see #111 