### PR TITLE
docs: fix project planner link

### DIFF
--- a/style/team.qmd
+++ b/style/team.qmd
@@ -45,7 +45,7 @@ The team is primarily remote. The Strategy Unit has two all company gathering a 
 
 Most of the team's time is working on a large project which we manage in an agile-like manner. We use GitHub to capture issues, and a project board to manage the sprint. 
 
-Tasks outside this project can be managed how you like. If you want to use GitHub, there is a [Data Science project planner](https://github.com/orgs/The-Strategy-Unit/projects/12).
+Tasks outside this project can be managed how you like. If you want to use GitHub, there is a [Data Science project planner](https://github.com/orgs/The-Strategy-Unit/projects?query=is%3Aopen).
 
 ## Coffee and Code
 


### PR DESCRIPTION
## Problem
The Data Science project planner link in `style/team.qmd` points to `https://github.com/orgs/The-Strategy-Unit/projects/12`, which currently returns 404. This matches the report in #428.

## Solution
Update the link to the organization's open projects listing suggested in the issue: `https://github.com/orgs/The-Strategy-Unit/projects?query=is%3Aopen`.

## Validation
- Confirmed the old `/projects/12` URL returns 404.
- Confirmed the replacement URL returns HTTP 200.
- Ran `git diff --check`.

Confidence: 85/100 (docs/broken-link)

Fixes #428
